### PR TITLE
Remove holidays from config

### DIFF
--- a/tt/tt.py
+++ b/tt/tt.py
@@ -345,8 +345,7 @@ def main():
         print(tot)
 
     elif command == "overtime" or command == "ot":
-        holidays = PUBLIC_HOLIDAY + config.get("days_off", [])
-        working_day = np.busday_count(YEAR, TODAY, weekmask='1111100', holidays=holidays)
+        working_day = np.busday_count(YEAR, TODAY, weekmask='1111100', holidays=PUBLIC_HOLIDAY)
         working_hours = (working_day * HOURS_PER_DAY) * int(config.get("percentage", 100))/100
 
         from_ = "{}-01-01".format(str(YEAR))


### PR DESCRIPTION
Per new rules, should now be put in timetracker as "Management -
Absence", so we don't need to take them into account when calculating
the overtime